### PR TITLE
Use 'want' value as old version and 'got' value as new version.

### DIFF
--- a/pretty/public.go
+++ b/pretty/public.go
@@ -98,19 +98,19 @@ func (cfg *Config) Fprint(w io.Writer, vals ...interface{}) (n int64, err error)
 }
 
 // Compare returns a string containing a line-by-line unified diff of the
-// values in got and want, using the CompareConfig.
+// values in want and got, using the CompareConfig.
 //
 // Each line in the output is prefixed with '+', '-', or ' ' to indicate if it
-// should be added to, removed from, or is correct for the "got" value with
-// respect to the "want" value.
-func Compare(got, want interface{}) string {
-	return CompareConfig.Compare(got, want)
+// should be added to, removed from, or is correct for the "want" value with
+// respect to the "got" value.
+func Compare(want, got interface{}) string {
+	return CompareConfig.Compare(want, got)
 }
 
 // Compare returns a string containing a line-by-line unified diff of the
-// values in got and want according to the cfg.
-func (cfg *Config) Compare(got, want interface{}) string {
+// values in want and got according to the cfg.
+func (cfg *Config) Compare(want, got interface{}) string {
 	diffCfg := *cfg
 	diffCfg.Diffable = true
-	return diff.Diff(cfg.Sprint(got), cfg.Sprint(want))
+	return diff.Diff(cfg.Sprint(want), cfg.Sprint(got))
 }


### PR DESCRIPTION
By doing so, you will see 'want' value with '-' prefix and 'got' value with '+' prefix, and it's more readable.