### PR TITLE
pretty: Catch cycles

### DIFF
--- a/pretty/doc.go
+++ b/pretty/doc.go
@@ -20,6 +20,3 @@
 //
 // See the Reflect and Print examples for what the output looks like.
 package pretty
-
-// TODO:
-//   - Catch cycles

--- a/pretty/public.go
+++ b/pretty/public.go
@@ -25,6 +25,8 @@ import (
 	"github.com/kylelemons/godebug/diff"
 )
 
+var emptyset = map[uintptr]bool{}
+
 // A Config represents optional configuration parameters for formatting.
 //
 // Some options, notably ShortList, dramatically increase the overhead
@@ -95,7 +97,7 @@ func (cfg *Config) fprint(buf *bytes.Buffer, vals ...interface{}) {
 		if i > 0 {
 			buf.WriteByte('\n')
 		}
-		cfg.val2node(reflect.ValueOf(val)).WriteTo(buf, "", cfg)
+		cfg.val2node(reflect.ValueOf(val), emptyset).WriteTo(buf, "", cfg)
 	}
 }
 

--- a/pretty/public.go
+++ b/pretty/public.go
@@ -25,8 +25,6 @@ import (
 	"github.com/kylelemons/godebug/diff"
 )
 
-var emptyset = map[uintptr]bool{}
-
 // A Config represents optional configuration parameters for formatting.
 //
 // Some options, notably ShortList, dramatically increase the overhead
@@ -97,7 +95,7 @@ func (cfg *Config) fprint(buf *bytes.Buffer, vals ...interface{}) {
 		if i > 0 {
 			buf.WriteByte('\n')
 		}
-		cfg.val2node(reflect.ValueOf(val), emptyset).WriteTo(buf, "", cfg)
+		cfg.val2node(reflect.ValueOf(val), map[uintptr]bool{}).WriteTo(buf, "", cfg)
 	}
 }
 

--- a/pretty/reflect_test.go
+++ b/pretty/reflect_test.go
@@ -121,7 +121,7 @@ func TestVal2nodeDefault(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got, want := DefaultConfig.val2node(reflect.ValueOf(test.raw)), test.want; !reflect.DeepEqual(got, want) {
+		if got, want := DefaultConfig.val2node(reflect.ValueOf(test.raw), emptyset), test.want; !reflect.DeepEqual(got, want) {
 			t.Errorf("%s: got %#v, want %#v", test.desc, got, want)
 		}
 	}
@@ -199,7 +199,7 @@ func TestVal2node(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got, want := test.cfg.val2node(reflect.ValueOf(test.raw)), test.want; !reflect.DeepEqual(got, want) {
+		if got, want := test.cfg.val2node(reflect.ValueOf(test.raw), emptyset), test.want; !reflect.DeepEqual(got, want) {
 			t.Errorf("%s: got %#v, want %#v", test.desc, got, want)
 		}
 	}

--- a/pretty/reflect_test.go
+++ b/pretty/reflect_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -203,4 +204,21 @@ func TestVal2node(t *testing.T) {
 			t.Errorf("%s: got %#v, want %#v", test.desc, got, want)
 		}
 	}
+}
+
+func TestRecursion(t *testing.T) {
+
+	type Recursive struct {
+		R *Recursive
+	}
+
+	r := &Recursive{}
+	r.R = r
+	x := Sprint(r)
+
+	if !strings.Contains(x, "recursion on") {
+		t.Errorf("Expected formatted string to contain 'recursion on', got: %q",
+			x)
+	}
+
 }

--- a/pretty/reflect_test.go
+++ b/pretty/reflect_test.go
@@ -122,7 +122,7 @@ func TestVal2nodeDefault(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got, want := DefaultConfig.val2node(reflect.ValueOf(test.raw), emptyset), test.want; !reflect.DeepEqual(got, want) {
+		if got, want := DefaultConfig.val2node(reflect.ValueOf(test.raw), map[uintptr]bool{}), test.want; !reflect.DeepEqual(got, want) {
 			t.Errorf("%s: got %#v, want %#v", test.desc, got, want)
 		}
 	}
@@ -200,7 +200,7 @@ func TestVal2node(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got, want := test.cfg.val2node(reflect.ValueOf(test.raw), emptyset), test.want; !reflect.DeepEqual(got, want) {
+		if got, want := test.cfg.val2node(reflect.ValueOf(test.raw), map[uintptr]bool{}), test.want; !reflect.DeepEqual(got, want) {
 			t.Errorf("%s: got %#v, want %#v", test.desc, got, want)
 		}
 	}


### PR DESCRIPTION
Hello up there. I was using godebug/pretty to pretty-print differences in tests and ran into infinite recursion in pretty.Compare() for datastructures with cycles. I looked around on github in godebug network and saw @pwaller already addressed this in 2013. So here are original patches by @pwaller which I rebased to recent master resolving minor conflicts along the way.

e.g. for the following example

```go
package main

import (
        "github.com/kylelemons/godebug/pretty"
)

type A struct {
        Ref *A
}

func main() {
        var a1, a2 A
        a1.Ref = &a2
        a2.Ref = &a1
        pretty.Print(a1)
}
```

previously the output was:

```
(neo) (g.env) kirr@deco:~/src/neo$ go run x.go
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

runtime stack:
runtime.throw(0x5094fc, 0xe)
        /home/kirr/src/tools/go/go/src/runtime/panic.go:605 +0x95
runtime.newstack(0x0)
        /home/kirr/src/tools/go/go/src/runtime/stack.go:1050 +0x6e1
runtime.morestack()
        /home/kirr/src/tools/go/go/src/runtime/asm_amd64.s:415 +0x86

goroutine 1 [running]:
reflect.packEface(0x4ed120, 0xc42000e038, 0x199, 0x0, 0x0)
        /home/kirr/src/tools/go/go/src/reflect/value.go:96 +0xfe fp=0xc440100348 sp=0xc440100340 pc=0x49ac4e
reflect.valueInterface(0x4ed120, 0xc42000e038, 0x199, 0x1, 0x0, 0x0)
        /home/kirr/src/tools/go/go/src/reflect/value.go:955 +0xe9 fp=0xc4401003a0 sp=0xc440100348 pc=0x49e479
reflect.Value.Interface(0x4ed120, 0xc42000e038, 0x199, 0x1, 0x0)
        /home/kirr/src/tools/go/go/src/reflect/value.go:925 +0x44 fp=0xc4401003e0 sp=0xc4401003a0 pc=0x49e364
github.com/kylelemons/godebug/pretty.(*Config).val2node(0x5a7dd0, 0x4ed120, 0xc42000e038, 0x199, 0xc42000e038, 0x199)
        /home/kirr/src/neo/src/github.com/kylelemons/godebug/pretty/reflect.go:40 +0x14bc fp=0xc4401007c0 sp=0xc4401003e0 pc=0x4c7c4c
github.com/kylelemons/godebug/pretty.(*Config).val2node(0x5a7dd0, 0x4d8280, 0xc42000e030, 0x196, 0x4d8280, 0xc42000e030)
        /home/kirr/src/neo/src/github.com/kylelemons/godebug/pretty/reflect.go:63 +0x94a fp=0xc440100ba0 sp=0xc4401007c0 pc=0x4c70da
github.com/kylelemons/godebug/pretty.(*Config).val2node(0x5a7dd0, 0x4ed120, 0xc42000e030, 0x199, 0xc42000e030, 0x199)
        /home/kirr/src/neo/src/github.com/kylelemons/godebug/pretty/reflect.go:95 +0xb62 fp=0xc440100f80 sp=0xc440100ba0 pc=0x4c72f2
github.com/kylelemons/godebug/pretty.(*Config).val2node(0x5a7dd0, 0x4d8280, 0xc42000e038, 0x196, 0x4d8280, 0xc42000e038)
        /home/kirr/src/neo/src/github.com/kylelemons/godebug/pretty/reflect.go:63 +0x94a fp=0xc440101360 sp=0xc440100f80 pc=0x4c70da
...
```

and with the patches it does not crash:

```
(neo) (g.env) kirr@deco:~/src/neo$ go run x.go
{Ref: {Ref: {Ref: [recursion on 0xc42000e038]}}}
```

So please apply.

Thanks beforehand,
Kirill