### PR TITLE
Add a `SkipStructField` config option for skipping struct fields.

### DIFF
--- a/pretty/public.go
+++ b/pretty/public.go
@@ -40,6 +40,10 @@ type Config struct {
 	PrintTextMarshalers bool // Call MarshalText on an encoding.TextMarshaler
 	SkipZeroFields      bool // Skip struct fields that have a zero value.
 
+	// If not nil, this will be called for each struct field to determine if
+	// it should be formatted or skipped.
+	SkipStructField     func(structType reflect.Type, field reflect.StructField) bool
+
 	// Output transforms
 	ShortList int // Maximum character length for short lists if nonzero.
 

--- a/pretty/reflect.go
+++ b/pretty/reflect.go
@@ -88,6 +88,9 @@ func (c *Config) val2node(val reflect.Value) node {
 			if !c.IncludeUnexported && sf.PkgPath != "" {
 				continue
 			}
+			if c.SkipStructField != nil && c.SkipStructField(typ, sf) {
+				continue
+			}
 			field := val.Field(i)
 			if c.SkipZeroFields && isZeroVal(field) {
 				continue


### PR DESCRIPTION
This is useful for comparing structs that expose non-deterministic
internal details as public fields, such as `XXX_*` in the Go protobuf
implementation.