### PR TITLE
Print only diffs

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -59,6 +59,24 @@ func Diff(A, B string) string {
 	return strings.TrimRight(buf.String(), "\n")
 }
 
+func OnlyDiff(A, B string) string {
+	aLines := strings.Split(A, "\n")
+	bLines := strings.Split(B, "\n")
+
+	chunks := DiffChunks(aLines, bLines)
+
+	buf := new(bytes.Buffer)
+	for _, c := range chunks {
+		for _, line := range c.Added {
+			fmt.Fprintf(buf, "+%s\n", line)
+		}
+		for _, line := range c.Deleted {
+			fmt.Fprintf(buf, "-%s\n", line)
+		}
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
 // DiffChunks uses an O(D(N+M)) shortest-edit-script algorithm
 // to compute the edits required from A to B and returns the
 // edit chunks.

--- a/pretty/public.go
+++ b/pretty/public.go
@@ -151,3 +151,20 @@ func (cfg *Config) Compare(a, b interface{}) string {
 	diffCfg.Diffable = true
 	return diff.Diff(cfg.Sprint(a), cfg.Sprint(b))
 }
+// Compare returns a string containing a line-by-line unified diff of the
+// values in a and b, using the CompareConfig.
+//
+// Each line in the output is prefixed with '+', '-' to indicate which
+// side it's from. Lines from the a side are marked with '-', lines from the
+// b side are marked with '+' and lines that are the same are not printed
+func CompareAndPrintDiff(a, b interface{}) string {
+	return CompareConfig.CompareAndPrintDiff(a, b)
+}
+
+// Compare returns a string containing a line-by-line unified diff of the
+// values in got and want according to the cfg.
+func (cfg *Config) CompareAndPrintDiff(a, b interface{}) string {
+	diffCfg := *cfg
+	diffCfg.Diffable = true
+	return diff.OnlyDiff(cfg.Sprint(a), cfg.Sprint(b))
+}

--- a/pretty/public.go
+++ b/pretty/public.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/kylelemons/godebug/diff"
+	"github.com/allamand/godebug/diff"
 )
 
 // A Config represents optional configuration parameters for formatting.

--- a/pretty/public.go
+++ b/pretty/public.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/allamand/godebug/diff"
+	"github.com/kylelemons/godebug/diff"
 )
 
 // A Config represents optional configuration parameters for formatting.
@@ -151,6 +151,7 @@ func (cfg *Config) Compare(a, b interface{}) string {
 	diffCfg.Diffable = true
 	return diff.Diff(cfg.Sprint(a), cfg.Sprint(b))
 }
+
 // Compare returns a string containing a line-by-line unified diff of the
 // values in a and b, using the CompareConfig.
 //


### PR DESCRIPTION
This update allows to print Only difference of the strict and not the lines that are equals.

This is useful when you have very large structure to compare, to quickly focus on what have changed