### PR TITLE
Add a transform option

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -226,3 +226,31 @@ States of America.
 	//  and our Posterity, do ordain and establish this Constitution for the United
 	//  States of America.
 }
+
+func TestDiffTransform(t *testing.T) {
+	a := strings.TrimSpace(`
+10:01 Line 1
+10:01 Line 2
+10:01 Line 3
+`)
+	b := strings.TrimSpace(`
+10:15 Line 1
+10:15 Line 2a
+10:15 Line 3
+`)
+	want := ` 10:01 Line 1
+-10:01 Line 2
++10:15 Line 2a
+ 10:01 Line 3`
+	got := Diff(a, b, Transform(
+		func(in string) string {
+			if len(in) < 6 {
+				return in
+			}
+			return in[6:]
+		}))
+	if got != want {
+		t.Errorf("GOT\n%#v\n", got)
+		t.Errorf("WANT\n%#v\n", want)
+	}
+}


### PR DESCRIPTION
This change adds a transform option to programatically alter the input before applying the diff. I find that I do this all the time. For example when diffing logs of program output: the timestamps of the logs are not interesting. However, sometimes the information in the original is germane to understanding the diffs, so the output should reference the original input before transformation.

I decided to do this as an option, rather than say, creating new entrypoints that explicitly take a transformation function for 2 reasons:
(1) This doesn't break existing usages, or create a new function.
(2) This allows for other options to be added in the future.

The way this is implemented, if there is no transform option, then no copying occurs.
