### PR TITLE
Add options to Diff and DiffChunk.

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -226,3 +226,31 @@ States of America.
 	//  and our Posterity, do ordain and establish this Constitution for the United
 	//  States of America.
 }
+
+func TestDiffTransform(t *testing.T) {
+	a := strings.TrimSpace(`
+10:01 Line 1
+10:01 Line 2
+10:01 Line 3
+`)
+	b := strings.TrimSpace(`
+10:15 Line 1
+10:15 Line 2a
+10:15 Line 3
+`)
+	want := ` 10:01 Line 1
+-10:01 Line 2
++10:15 Line 2a
+ 10:01 Line 3`
+	got := Diff(a, b, Transform(
+		func(in string) string {
+			if len(in) < 6 {
+				return in
+			}
+			return in[6:]
+		}))
+	if got != want {
+		t.Errorf("GOT\n%#v\n", got)
+		t.Errorf("WANT\n%#v\n", want)
+	}
+}


### PR DESCRIPTION
This commit adds options to Diff and DiffChunks. The only option I've implemented is Transform, which is a function to modify lines before diffing.

I find myself often having to modify files before diffing so that I can ignore differences I don't care about and concentrate on those I do. One example might be diffing the log output of a program running at different times, where you want to ignore the timestamp. There are many others. However, the problem with modifying the lines before diffing is that I'd like the output and context lines to refer to the original lines before they were modified. That is what the Transform option does.

Note that if a transform is not provided then no copying is done, and there is no change to the calling convention for existing callers. If there are additional options in the future, they have be added to the options structure.