### PR TITLE
Fix isZeroVal comparision for non pointer and struct fields inside a struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -23,30 +23,36 @@ import (
 
 func TestDiff(t *testing.T) {
 	tests := []struct {
-		desc   string
-		A, B   []string
-		chunks []Chunk
+		desc           string
+		A, B           []string
+		chunks         []Chunk
+		diffPercentage float64
 	}{
 		{
-			desc: "nil",
+			desc:           "nil",
+			diffPercentage: 1,
 		},
 		{
-			desc: "empty",
-			A:    []string{},
-			B:    []string{},
+			desc:           "empty",
+			A:              []string{},
+			B:              []string{},
+			diffPercentage: 1,
 		},
 		{
-			desc: "same",
-			A:    []string{"foo"},
-			B:    []string{"foo"},
+			desc:           "same",
+			A:              []string{"foo"},
+			B:              []string{"foo"},
+			diffPercentage: 1,
 		},
 		{
-			desc: "a empty",
-			A:    []string{},
+			desc:           "a empty",
+			A:              []string{},
+			diffPercentage: 1,
 		},
 		{
-			desc: "b empty",
-			B:    []string{},
+			desc:           "b empty",
+			B:              []string{},
+			diffPercentage: 1,
 		},
 		{
 			desc: "b nil",
@@ -54,6 +60,7 @@ func TestDiff(t *testing.T) {
 			chunks: []Chunk{
 				0: {Deleted: []string{"foo"}},
 			},
+			diffPercentage: 1,
 		},
 		{
 			desc: "a nil",
@@ -61,6 +68,7 @@ func TestDiff(t *testing.T) {
 			chunks: []Chunk{
 				0: {Added: []string{"foo"}},
 			},
+			diffPercentage: 1,
 		},
 		{
 			desc: "start with change",
@@ -70,6 +78,7 @@ func TestDiff(t *testing.T) {
 				0: {Deleted: []string{"a"}},
 				1: {Added: []string{"A"}, Equal: []string{"b", "c"}},
 			},
+			diffPercentage: 1.0 / 3,
 		},
 		{
 			desc: "constitution",
@@ -109,12 +118,41 @@ func TestDiff(t *testing.T) {
 					},
 				},
 			},
+			diffPercentage: 0.2,
+		},
+		{
+			desc: "real case",
+			A: []string{
+				`Street: "26642 TOWNE CENTRE DRIVE ",`,
+				`Price: "$81,500",`,
+			},
+			B: []string{
+				`Street: "26642 TOWNE CENTRE DRIVE",`,
+				`Price: "$81,500",`,
+			},
+			chunks: []Chunk{
+				0: {
+					Deleted: []string{
+						`Street: "26642 TOWNE CENTRE DRIVE ",`,
+					},
+				},
+				1: {
+					Added: []string{
+						`Street: "26642 TOWNE CENTRE DRIVE",`,
+					},
+					Equal: []string{
+						`Price: "$81,500",`,
+					},
+				},
+			},
+			diffPercentage: 0.5,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			got := DiffChunks(test.A, test.B)
+			got, _ := DiffChunks(test.A, test.B)
+
 			if got, want := len(got), len(test.chunks); got != want {
 				t.Errorf("edit distance = %v, want %v", got-1, want-1)
 				return
@@ -224,5 +262,5 @@ States of America.
 	// -and secure the Blessings of Liberty to ourselves
 	// +promote the general Welfare, and secure the Blessings of Liberty to ourselves
 	//  and our Posterity, do ordain and establish this Constitution for the United
-	//  States of America.
+	//  States of America. 0.2727272727272727
 }

--- a/pretty/examples_test.go
+++ b/pretty/examples_test.go
@@ -37,10 +37,10 @@ func ExampleConfig_Sprint() {
 			"player2": {0, -1},
 		},
 		Obstacles: map[Pair]string{
-			Pair{0, 0}: "rock",
-			Pair{2, 1}: "pond",
-			Pair{1, 1}: "stream",
-			Pair{0, 1}: "stream",
+			{0, 0}: "rock",
+			{2, 1}: "pond",
+			{1, 1}: "stream",
+			{0, 1}: "stream",
 		},
 	}
 
@@ -220,7 +220,7 @@ func ExampleCompare_testing() {
 
 	for _, test := range tests {
 		AddCrew(test.before, test.name, test.title)
-		if diff := pretty.Compare(test.before, test.after); diff != "" {
+		if diff, _ := pretty.Compare(test.before, test.after); diff != "" {
 			t.Errorf("%s: post-AddCrew diff: (-got +want)\n%s", test.desc, diff)
 		}
 	}
@@ -306,7 +306,7 @@ func ExampleCompare_debugging() {
 	//   Androids: 1,
 	// - Stolen: true,
 	// + Stolen: false,
-	//  }
+	//  } 0.3
 }
 
 type ListNode struct {
@@ -354,7 +354,8 @@ func ExampleCompare_withCycles() {
 	// Make the got one broken
 	got.Next.Next.Next = got.Next
 
-	fmt.Printf("Diff: (-got +want)\n%s", pretty.CycleTracker.Compare(got, want))
+	result, _ := pretty.CycleTracker.Compare(got, want)
+	fmt.Printf("Diff: (-got +want)\n%s", result)
 
 	// Output:
 	// Diff: (-got +want)

--- a/pretty/public.go
+++ b/pretty/public.go
@@ -73,6 +73,14 @@ type Config struct {
 	//
 	// Pointer tracking is disabled by default for performance reasons.
 	TrackCycles bool
+
+	// If IgnoreMoneyFormatDifferences is enabled, pretty will ignore
+	// differences in the format of currency values.
+	IgnoreMoneyFormatDifferences bool
+
+	// If TrimSpaceOfStrings is enabled, pretty will trim spaces from the
+	// beginning and the end of strings.
+	TrimSpaceOfStrings bool
 }
 
 // Default Config objects

--- a/pretty/public.go
+++ b/pretty/public.go
@@ -154,7 +154,8 @@ func (cfg *Config) Fprint(w io.Writer, vals ...interface{}) (n int64, err error)
 }
 
 // Compare returns a string containing a line-by-line unified diff of the
-// values in a and b, using the CompareConfig.
+// values in a and b, using the CompareConfig and a float64 containing the
+// ratio of differences.
 //
 // Each line in the output is prefixed with '+', '-', or ' ' to indicate which
 // side it's from. Lines from the a side are marked with '-', lines from the
@@ -165,12 +166,13 @@ func (cfg *Config) Fprint(w io.Writer, vals ...interface{}) (n int64, err error)
 // such this comparison is pretty forviving.  In particular, if the types of or
 // types within in a and b are different but have the same representation,
 // Compare will not indicate any differences between them.
-func Compare(a, b interface{}) string {
+func Compare(a, b interface{}) (string, float64) {
 	return CompareConfig.Compare(a, b)
 }
 
 // Compare returns a string containing a line-by-line unified diff of the
-// values in got and want according to the cfg.
+// values in got and want according to the cfg and a float64 containing the
+// ratio of differences.
 //
 // Each line in the output is prefixed with '+', '-', or ' ' to indicate which
 // side it's from. Lines from the a side are marked with '-', lines from the
@@ -181,7 +183,7 @@ func Compare(a, b interface{}) string {
 // such this comparison is pretty forviving.  In particular, if the types of or
 // types within in a and b are different but have the same representation,
 // Compare will not indicate any differences between them.
-func (cfg *Config) Compare(a, b interface{}) string {
+func (cfg *Config) Compare(a, b interface{}) (string, float64) {
 	diffCfg := *cfg
 	diffCfg.Diffable = true
 	return diff.Diff(cfg.Sprint(a), cfg.Sprint(b))

--- a/pretty/public_test.go
+++ b/pretty/public_test.go
@@ -64,7 +64,8 @@ func TestDiff(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got, want := Compare(test.got, test.want), test.diff; got != want {
+		got, _ := Compare(test.got, test.want)
+		if want := test.diff; got != want {
 			t.Errorf("%s:", test.desc)
 			t.Errorf("  got:  %q", got)
 			t.Errorf("  want: %q", want)
@@ -120,7 +121,8 @@ func TestSkipZeroFields(t *testing.T) {
 	cfg.SkipZeroFields = true
 
 	for _, test := range tests {
-		if got, want := cfg.Compare(test.got, test.want), test.diff; got != want {
+		got, _ := cfg.Compare(test.got, test.want)
+		if want := test.diff; got != want {
 			t.Errorf("%s:", test.desc)
 			t.Errorf("  got:  %q", got)
 			t.Errorf("  want: %q", want)

--- a/pretty/public_test.go
+++ b/pretty/public_test.go
@@ -184,3 +184,40 @@ func TestNilvsEmptyStruct(t *testing.T) {
 		t.Errorf("WANT\n%#v\n%f", want, wantPercentage)
 	}
 }
+
+func TestIgnoreMoneyFormatDifferences(t *testing.T) {
+	type example struct {
+		Price string
+	}
+
+	tests := []struct {
+		desc      string
+		got, want interface{}
+		diff      string
+	}{
+		{
+			desc: "basic struct",
+			got: example{
+				Price: "3456.00",
+			},
+			want: example{
+				Price: "$3,456.00",
+			},
+			diff: ` {
+	Price: "3456",
+ }`,
+		},
+	}
+
+	cfg := *CompareConfig
+	cfg.IgnoreMoneyFormatDifferences = true
+
+	for _, test := range tests {
+		got, _ := cfg.Compare(test.got, test.want)
+		if want := test.diff; got != want {
+			t.Errorf("%s:", test.desc)
+			t.Errorf("  got:  %q", got)
+			t.Errorf("  want: %q", want)
+		}
+	}
+}

--- a/pretty/public_test.go
+++ b/pretty/public_test.go
@@ -203,9 +203,6 @@ func TestIgnoreMoneyFormatDifferences(t *testing.T) {
 			want: example{
 				Price: "$3,456.00",
 			},
-			diff: ` {
-	Price: "3456",
- }`,
 		},
 	}
 

--- a/pretty/public_test.go
+++ b/pretty/public_test.go
@@ -155,3 +155,32 @@ func TestRegressions(t *testing.T) {
 		})
 	}
 }
+
+func TestNilvsEmptyStruct(t *testing.T) {
+	type Bar struct {
+		Value string
+	}
+
+	type Foo struct {
+		Bar *Bar
+	}
+
+	a := Foo{
+		Bar: nil,
+	}
+
+	b := Foo{
+		Bar: &Bar{
+			Value: "",
+		},
+	}
+
+	want := ""
+	wantPercentage := 1.0
+
+	got, gotPercentage := Compare(a, b)
+	if got != want || wantPercentage != gotPercentage {
+		t.Errorf("GOT\n%#v\n%f", got, gotPercentage)
+		t.Errorf("WANT\n%#v\n%f", want, wantPercentage)
+	}
+}

--- a/pretty/reflect.go
+++ b/pretty/reflect.go
@@ -33,14 +33,8 @@ func isZeroVal(val reflect.Value) bool {
 		fields := typ.NumField()
 		for i := 0; i < fields; i++ {
 			sf := typ.Field(i)
-			if sf.Type.Kind() == reflect.Ptr || sf.Type.Kind() == reflect.Struct {
-				if !isZeroVal(val.Field(i)) {
-					return false
-				}
-			} else {
-				if !reflect.DeepEqual(val.Interface(), z) {
-					return false
-				}
+			if !isZeroVal(val.Field(i)) {
+				return false
 			}
 		}
 		return true

--- a/pretty/reflect.go
+++ b/pretty/reflect.go
@@ -46,7 +46,7 @@ func isZeroVal(val reflect.Value) bool {
 		return true
 	}
 
-	if val.Type().Kind() == reflect.Pointer {
+	if val.Type().Kind() == reflect.Ptr {
 		if val.IsNil() || isZeroVal(val.Elem()) {
 			return true
 		}

--- a/pretty/reflect.go
+++ b/pretty/reflect.go
@@ -155,7 +155,7 @@ func (r *reflector) val2node(val reflect.Value) (ret node) {
 
 	switch kind := val.Kind(); kind {
 	case reflect.Ptr:
-		if val.IsNil() {
+		if val.IsNil() || isZeroVal(val.Elem()) {
 			return rawVal("nil")
 		}
 		return r.follow(val.Pointer(), val.Elem())

--- a/pretty/reflect_test.go
+++ b/pretty/reflect_test.go
@@ -75,9 +75,9 @@ func TestVal2nodeDefault(t *testing.T) {
 		{
 			desc: "map of [2]int",
 			raw: map[[2]int]string{
-				[2]int{-1, 2}: "school",
-				[2]int{0, 0}:  "origin",
-				[2]int{1, 3}:  "home",
+				{-1, 2}: "school",
+				{0, 0}:  "origin",
+				{1, 3}:  "home",
 			},
 			want: keyvals{
 				{"[-1,2]", stringVal("school")},
@@ -306,7 +306,8 @@ func TestVal2node(t *testing.T) {
 			if got, want := ref.val2node(reflect.ValueOf(test.raw)), test.want; !reflect.DeepEqual(got, want) {
 				t.Errorf(" got %#v", got)
 				t.Errorf("want %#v", want)
-				t.Errorf("Diff: (-got +want)\n%s", Compare(got, want))
+				result, _ := Compare(got, want)
+				t.Errorf("Diff: (-got +want)\n%s", result)
 			}
 		})
 	}
@@ -380,9 +381,9 @@ func BenchmarkVal2node(b *testing.B) {
 			desc: "map",
 			cfg:  DefaultConfig,
 			raw: map[[2]int]string{
-				[2]int{-1, 2}: "school",
-				[2]int{0, 0}:  "origin",
-				[2]int{1, 3}:  "home",
+				{-1, 2}: "school",
+				{0, 0}:  "origin",
+				{1, 3}:  "home",
 			},
 		},
 		{
@@ -394,9 +395,9 @@ func BenchmarkVal2node(b *testing.B) {
 			desc: "track/map",
 			cfg:  CycleTracker,
 			raw: map[[2]int]string{
-				[2]int{-1, 2}: "school",
-				[2]int{0, 0}:  "origin",
-				[2]int{1, 3}:  "home",
+				{-1, 2}: "school",
+				{0, 0}:  "origin",
+				{1, 3}:  "home",
 			},
 		},
 		{

--- a/pretty/reflect_test.go
+++ b/pretty/reflect_test.go
@@ -116,7 +116,7 @@ func TestVal2nodeDefault(t *testing.T) {
 		{
 			desc: "nil error",
 			raw:  &errNil,
-			want: rawVal("<nil>"),
+			want: rawVal("nil"),
 		},
 	}
 

--- a/pretty/reflect_test.go
+++ b/pretty/reflect_test.go
@@ -25,6 +25,7 @@ import (
 func TestVal2nodeDefault(t *testing.T) {
 	err := fmt.Errorf("err")
 	var errNil error
+	var emptyString string
 
 	tests := []struct {
 		desc string
@@ -92,6 +93,18 @@ func TestVal2nodeDefault(t *testing.T) {
 				{"Zaphod", stringVal("beeblebrox")},
 				{"Ford", stringVal("prefect")},
 			},
+		},
+		{
+			desc: "complex struct",
+			raw:  &struct{ Zaphod, Ford *string }{&emptyString, nil},
+			want: rawVal("nil"),
+		},
+		{
+			desc: "complex nested struct",
+			raw: &struct {
+				EmbeddedStruct struct{ Zaphod, Ford *string }
+			}{EmbeddedStruct: struct{ Zaphod, Ford *string }{&emptyString, nil}},
+			want: rawVal("nil"),
 		},
 		{
 			desc: "int",


### PR DESCRIPTION
Inside of a struct, for non pointer and struct fields, we were calling deepEqual on the struct val and struct zero val rather than on the field and field zero val.  Adjusted this so it recursively uses isZeroVal and simplifies the function as a whole.